### PR TITLE
feat: config.yaml 기반 동적 파라미터 공간 생성 기능 구현

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -31,6 +31,40 @@ strategy_params:
   max_splits_limit: 15 # 최대 분할매수 차수 (10차까지)
   max_inactivity_period: 43     # (정적) 최대 매매 미발생 기간 (일)
 
+# [추가] GPU 대량 시뮬레이션을 위한 파라미터 공간 정의
+parameter_space:
+  max_stocks:
+    type: 'list'
+    values: [20]
+  order_investment_ratio:
+    type: 'linspace'
+    start: 0.02
+    stop: 0.05
+    num: 4 # 0.02, 0.03, 0.04, 0.05
+  additional_buy_drop_rate:
+    type: 'range'
+    start: 0.04
+    stop: 0.12 # 0.12는 포함되지 않음
+    step: 0.02 # 0.04, 0.06, 0.08, 0.10
+  sell_profit_rate:
+    type: 'list'
+    values: [0.14, 0.16, 0.18, 0.20, 0.22]
+  additional_buy_priority:
+    type: 'list' # 문자열 대신 숫자로 매핑 (0: lowest_order, 1: highest_drop)
+    values: [1]
+  stop_loss_rate:
+    type: 'list'
+    values: [-0.4, -0.5, -0.6, -0.7]
+  max_splits_limit:
+    type: 'list'
+    values: [15]
+  max_inactivity_period:
+    type: 'range'
+    start: 30
+    stop: 181 # 181은 포함되지 않음
+    step: 30 # 30, 60, 90, 120, 150, 180
+
+
 # --- 4. Execution Handler Parameters ---
 execution_params:
   buy_commission_rate: 0.00015


### PR DESCRIPTION
#### **1. 개요 (Overview)**

이 Merge Request는 GPU 대규모 시뮬레이션(`parameter_simulation_gpu.py`)에서 사용하는 파라미터 공간(Parameter Space)의 정의를 소스 코드에서 `config.yaml` 설정 파일로 이전하는 것을 목표로 합니다. 이를 통해 코드 수정 없이 파라미터 탐색 범위를 동적으로 제어하여 연구 및 실험의 유연성을 극대화합니다.

#### **2. 변경 사항 (Changes)**

-   **`config.yaml`:**
    -   GPU 대량 시뮬레이션 전용 `parameter_space` 섹션을 신설했습니다.
    -   `linspace`, `range`, `list` 세 가지 타입을 지원하여 다양한 형태의 파라미터 공간을 정의할 수 있습니다.
    -   기존의 `strategy_params` 섹션은 CPU 및 단일 GPU 실행과의 하위 호환성을 위해 **변경 없이 그대로 유지**했습니다.

-   **`src/parameter_simulation_gpu.py`:**
    -   기존에 하드코딩되어 있던 파라미터 옵션(`max_stocks_options` 등) 부분을 모두 삭제했습니다.
    -   `config.yaml`의 `parameter_space` 섹션을 읽어 파라미터 조합(`param_combinations`)을 동적으로 생성하는 로직을 구현했습니다.

#### **3. 기대 효과 (Expected Effects)**

-   **유연성 향상:** 이제 `config.yaml` 파일 수정만으로 다양한 파라미터 최적화 시나리오를 손쉽게 실행할 수 있습니다.
-   **유지보수성 개선:** 파라미터 정의가 설정 파일로 분리됨에 따라, 소스 코드의 역할이 명확해지고 가독성이 향상됩니다.
-   **재현성 확보:** 특정 실험에 사용된 `config.yaml` 파일을 함께 보관하면, 언제든지 동일한 조건의 파라미터 시뮬레이션을 완벽하게 재현할 수 있습니다.

#### **4. 검증 내역 (Verification)**

-   **[✓] 동적 생성 검증:** `parameter_simulation_gpu.py` 단독 실행 시, `config.yaml`에 정의된 대로 올바른 수의 파라미터 조합이 생성됨을 확인했습니다.
-   **[✓] CPU 백테스터 호환성 검증:** `main_backtest.py`가 기존 `strategy_params`를 사용하여 정상적으로 실행됨을 확인했습니다.
-   **[✓] 단일 GPU 실행 호환성 검증:** `debug_gpu_single_run.py`가 기존 `strategy_params`를 사용하여 정상적으로 실행됨을 확인했습니다.

#### **5. 관련 이슈 (Related Issues)**

-   Closes #45 
---