### PR TITLE
  test(issue69): extend entrypoint compatibility guards to main modules

### DIFF
--- a/src/data_handler.py
+++ b/src/data_handler.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import warnings
-from mysql.connector import pooling
 from functools import lru_cache
 from datetime import timedelta
 
@@ -16,9 +15,19 @@ class DataHandler:
     def __init__(self, db_config):
         self.db_config = db_config
         try:
-            self.connection_pool = pooling.MySQLConnectionPool(pool_name="data_pool",
-                                                               pool_size=10,
-                                                               **self.db_config)
+            try:
+                from mysql.connector import pooling as mysql_pooling
+            except ModuleNotFoundError as err:
+                raise ModuleNotFoundError(
+                    "mysql-connector-python is required for DataHandler DB access. "
+                    "Install it (e.g. `pip install mysql-connector-python`) in your active environment."
+                ) from err
+
+            self.connection_pool = mysql_pooling.MySQLConnectionPool(
+                pool_name="data_pool",
+                pool_size=10,
+                **self.db_config,
+            )
             self._load_company_info_cache()
         except Exception as e:
             print(f"DB 연결 풀 생성 또는 캐시 로딩 실패: {e}")

--- a/src/main_backtest.py
+++ b/src/main_backtest.py
@@ -23,7 +23,6 @@ from .strategy import MagicSplitStrategy
 from .portfolio import Portfolio
 from .execution import BasicExecutionHandler
 from .backtester import BacktestEngine
-from .performance_analyzer import PerformanceAnalyzer 
 from .config_loader import load_config
 # company_info_manager는 이제 DataHandler가 내부적으로 사용하므로 여기서 직접 임포트할 필요가 없습니다.
 
@@ -82,6 +81,8 @@ def run_backtest_from_config(config: dict) -> dict:
     daily_values_for_response = history_df['total_value']
 
     try:
+        from .performance_analyzer import PerformanceAnalyzer
+
         # PerformanceAnalyzer는 이제 전체 history_df를 받습니다.
         analyzer = PerformanceAnalyzer(history_df)
         raw_metrics = analyzer.get_metrics(formatted=False)

--- a/src/main_script.py
+++ b/src/main_script.py
@@ -19,18 +19,19 @@ if __name__ == "__main__" and (__package__ is None or __package__ == ""):
     sys.path.insert(0, str(file_path.parent.parent))
     __package__ = file_path.parent.name  # "src"
 
-# db_setup에서 DB 연결 및 테이블 생성 함수 임포트
-from .db_setup import get_db_connection, create_tables 
-
-# 각 기능 모듈 임포트
-from . import company_info_manager
-from . import weekly_stock_filter_parser
-from . import ohlcv_collector
-from . import indicator_calculator
-from . import filtered_stock_loader
 from .config_loader import load_config, resolve_project_path
 
-if __name__ == "__main__":
+
+def main() -> None:
+    """Run the legacy/general data pipeline with config-driven flags."""
+    # Lazy imports keep module import-safe in no-DB/no-pykrx notebook environments.
+    from .db_setup import get_db_connection, create_tables
+    from . import company_info_manager
+    from . import weekly_stock_filter_parser
+    from . import ohlcv_collector
+    from . import indicator_calculator
+    from . import filtered_stock_loader
+
     db_connection = None  # DB 커넥션 객체 초기화
     try:
         config = load_config()
@@ -71,29 +72,32 @@ if __name__ == "__main__":
         calculate_indicators = bool(pipeline_flags.get("calculate_indicators", True))
 
         # --- DB 연결 및 테이블 생성 ---
-        db_connection = get_db_connection() # MySQL DB 연결
+        db_connection = get_db_connection()  # MySQL DB 연결
         if db_connection:
             print("MySQL 데이터베이스 연결 성공.")
-            create_tables(db_connection) # 필요한 모든 테이블 확인/생성
+            create_tables(db_connection)  # 필요한 모든 테이블 확인/생성
             print("데이터베이스 테이블 확인/생성 완료.")
         else:
             print("CRITICAL: MySQL 데이터베이스 연결에 실패했습니다. 프로그램을 종료합니다.")
-            exit()
+            return
 
         # --- STEP 0: (선택적) CompanyInfo DB 업데이트 ---
-        print("\n" + "="*50)
+        print("\n" + "=" * 50)
         print("STEP 0: CompanyInfo DB 업데이트 확인 및 실행")
-        print("="*50)
+        print("=" * 50)
         if update_company_info_db:
             print("CompanyInfo DB를 최신 정보로 업데이트합니다. (시간 소요 예상)")
-            company_info_manager.update_company_info_from_pykrx(db_connection, target_date_str=datetime.today().strftime("%Y%m%d"))
+            company_info_manager.update_company_info_from_pykrx(
+                db_connection,
+                target_date_str=datetime.today().strftime("%Y%m%d"),
+            )
         else:
             print("CompanyInfo DB 업데이트는 건너뜁니다. 기존 DB를 사용합니다.")
 
         # --- STEP 1: CompanyInfo 캐시 로딩 ---
-        print("\n" + "="*50)
+        print("\n" + "=" * 50)
         print("STEP 1: CompanyInfo 캐시 로딩 (DB에서)")
-        print("="*50)
+        print("=" * 50)
         company_info_manager.load_company_info_cache_from_db(db_connection)
         if not company_info_manager.STOCK_NAME_TO_CODE_CACHE:
             print("CRITICAL: CompanyInfo 캐시가 비어있거나 로드에 실패했습니다.")
@@ -102,15 +106,15 @@ if __name__ == "__main__":
 
         # --- STEP 2: 주간 필터링 CSV 처리 및 DB 저장 ---
         if process_hts_csv_files:
-            print("\n" + "="*50)
-            print(f"STEP 2: 주간 필터링 CSV 파일 파싱 및 종목코드 매핑, WeeklyFilteredStocks DB 저장 시작")
+            print("\n" + "=" * 50)
+            print("STEP 2: 주간 필터링 CSV 파일 파싱 및 종목코드 매핑, WeeklyFilteredStocks DB 저장 시작")
             print(f"대상 폴더: {condition_search_files_folder}")
-            print("="*50)
+            print("=" * 50)
             weekly_stock_filter_parser.process_all_hts_csv_files(
-                conn=db_connection, # MySQL connection 전달
+                conn=db_connection,
                 csv_folder_path=str(condition_search_files_folder),
                 processed_data_folder_path=str(processed_data_folder),
-                company_manager_module=company_info_manager 
+                company_manager_module=company_info_manager,
             )
             print("주간 필터링 CSV 처리 및 WeeklyFilteredStocks DB 저장 완료.")
         else:
@@ -118,10 +122,10 @@ if __name__ == "__main__":
 
         # --- STEP 2.5: 최종 필터링된 주간 종목 리스트 DB에 적재 ---
         if load_filtered_stocks_csv:
-            print("\n" + "="*50)
-            print(f"STEP 2.5: 최종 필터링된 주간 종목 CSV 파일 DB 적재 시작")
+            print("\n" + "=" * 50)
+            print("STEP 2.5: 최종 필터링된 주간 종목 CSV 파일 DB 적재 시작")
             print(f"대상 파일: {filtered_stocks_csv_path}")
-            print("="*50)
+            print("=" * 50)
             db_engine = filtered_stock_loader.get_db_engine(config.get("database"))
             filtered_stock_loader.load_filtered_stocks_to_db(str(filtered_stocks_csv_path), db_engine)
         else:
@@ -129,14 +133,14 @@ if __name__ == "__main__":
 
         # --- STEP 3: OHLCV 데이터 수집 및 DB 저장 ---
         if collect_ohlcv_data:
-            print("\n" + "="*50)
+            print("\n" + "=" * 50)
             print("STEP 3: OHLCV 데이터 수집 및 DailyStockPrice DB 저장 시작")
-            print("="*50)
+            print("=" * 50)
             ohlcv_collector.collect_and_save_ohlcv_for_filtered_stocks(
-                conn=db_connection, # MySQL connection 전달
+                conn=db_connection,
                 company_manager=company_info_manager,
                 overall_end_date_str=datetime.today().strftime("%Y%m%d"),
-                force_recollect=force_recollect_ohlcv # 재수집 플래그 전달
+                force_recollect=force_recollect_ohlcv,
             )
             print("OHLCV 데이터 수집 및 DailyStockPrice DB 저장 완료.")
         else:
@@ -153,9 +157,14 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"\n[메인 스크립트 오류] 예외 발생: {e}")
         import traceback
-        traceback.print_exc() # 상세 오류 스택 출력
+
+        traceback.print_exc()
 
     finally:
         if db_connection:
             db_connection.close()
             print("\nMySQL 데이터베이스 연결 해제됨.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_issue69_entrypoint_compat.py
+++ b/tests/test_issue69_entrypoint_compat.py
@@ -32,6 +32,8 @@ class _Blocker(importlib.abc.MetaPathFinder):
 sys.meta_path.insert(0, _Blocker())
 
 for name in [
+    "src.main_backtest",
+    "src.main_script",
     "src.walk_forward_analyzer",
     "src.parameter_simulation_gpu",
     "src.pipeline_batch",
@@ -60,6 +62,13 @@ for name in [
         )
 
     def test_entrypoints_export_expected_symbols(self):
+        main_backtest = importlib.import_module("src.main_backtest")
+        self.assertTrue(hasattr(main_backtest, "main"))
+        self.assertTrue(hasattr(main_backtest, "run_backtest_from_config"))
+
+        main_script = importlib.import_module("src.main_script")
+        self.assertTrue(hasattr(main_script, "main"))
+
         pipeline_batch = importlib.import_module("src.pipeline_batch")
         self.assertTrue(hasattr(pipeline_batch, "run_pipeline_batch"))
 

--- a/todos/2026_02_16-issue69-src-package-restructure-breakdown.md
+++ b/todos/2026_02_16-issue69-src-package-restructure-breakdown.md
@@ -286,8 +286,12 @@
   - `python -m unittest tests.test_issue60_import_side_effects tests.test_issue61_import_style_standardization tests.test_issue68_wfo_import_side_effects tests.test_issue69_entrypoint_compat tests.test_issue69_parameter_simulation_wrapper_compat -v`
 
 ### 6-11. PR-10: 엔트리포인트 호환성 가드 보강(DoD Gate)
-- [ ] `tests/test_issue69_entrypoint_compat.py`: `src.main_backtest`, `src.main_script` import 가드 추가
-- [ ] (선택) `src/main_script.py`: `main()` 함수 도입 + `if __name__ == \"__main__\": main()`로 정리(동작 동일)
+- [x] `tests/test_issue69_entrypoint_compat.py`: `src.main_backtest`, `src.main_script` import 가드 추가
+- [x] `src/main_script.py`: `main()` 함수 도입 + `if __name__ == \"__main__\": main()`로 정리(동작 동일)
+- [x] `src/data_handler.py`: `mysql.connector` import를 `DataHandler.__init__` 내부 lazy import로 전환(no-DB import-safe)
+- [x] `src/main_backtest.py`: `PerformanceAnalyzer` import를 함수 내부 lazy import로 전환(import 시 matplotlib 의존 제거)
+- [x] 테스트 통과:
+  - `python -m unittest tests.test_issue60_import_side_effects tests.test_issue61_import_style_standardization tests.test_issue68_wfo_import_side_effects tests.test_issue69_entrypoint_compat -v`
 
 ### 6-12. PR-11: import 경로 변경 가이드 문서화(DoD Gate)
 - [ ] `docs/refactoring/issue69-import-path-mapping.md`: 이전 import 경로 -> 신규 경로 매핑 테이블 작성


### PR DESCRIPTION
 ## Summary
  - Extend Issue #69 entrypoint compatibility guard tests to include:
    - `src.main_backtest`
    - `src.main_script`
  - Improve import-safety in no-DB/no-GPU notebook-like environments:
    - Move `mysql.connector` import in `src/data_handler.py` to lazy import inside
  `DataHandler.__init__`
    - Move `PerformanceAnalyzer` import in `src/main_backtest.py` to function-local lazy import
    - Refactor `src/main_script.py` to `main()` entrypoint + lazy imports for DB/collector modules
  - Update Issue #69 todo checklist (PR-10 section)

  ## Why
  - PR-10 DoD requires stronger entrypoint import guards.
  - In minimal environments, top-level imports should not fail before execution path is selected.

  ## Files Changed
  - `src/data_handler.py`
  - `src/main_backtest.py`
  - `src/main_script.py`
  - `tests/test_issue69_entrypoint_compat.py`
  - `todos/2026_02_16-issue69-src-package-restructure-breakdown.md`

  ## Validation
  - `python -m unittest tests.test_issue60_import_side_effects
  tests.test_issue61_import_style_standardization tests.test_issue68_wfo_import_side_effects
  tests.test_issue69_entrypoint_compat -v`
  - Result: `OK`

  ## Scope / Non-goals
  - No strategy/execution logic changes
  - No DB schema changes
  - No GPU kernel logic changes