### PR TITLE
docs(issue69): add import path mapping guide

### DIFF
--- a/docs/refactoring/issue69-import-path-mapping.md
+++ b/docs/refactoring/issue69-import-path-mapping.md
@@ -1,0 +1,78 @@
+# Issue #69 Import Path Mapping
+
+- Scope: `src` 패키지 구조 재편 이슈(#69)에서 변경된 import 경로 매핑
+- Status date: 2026-02-16
+- Source todo: `todos/2026_02_16-issue69-src-package-restructure-breakdown.md`
+
+## 1. 원칙
+
+- 기존 top-level 모듈(`src/*.py`)은 호환성 wrapper로 유지합니다.
+- 신규/내부 구현 import는 하위 패키지 구현 경로를 우선 사용합니다.
+- 엔트리포인트 실행 커맨드(`python -m src.<entrypoint>`)는 기존과 동일하게 유지합니다.
+- `PR-7`(`backtest_strategy_gpu` 분해)은 아직 미완료이므로, 해당 경로는 "현행 유지" 상태입니다.
+
+## 2. 경로 매핑 표
+
+| 영역 | 기존/호환 경로 | 신규 구현 경로 | 상태 | 비고 |
+| --- | --- | --- | --- | --- |
+| Pipeline orchestrator | `src.pipeline_batch` | `src.pipeline.batch` | Done | wrapper 유지 |
+| Ticker universe batch | `src.ticker_universe_batch` | `src.pipeline.ticker_universe_batch` | Done | wrapper 유지 |
+| OHLCV batch | `src.ohlcv_batch` | `src.pipeline.ohlcv_batch` | Done | wrapper 유지 |
+| Daily tier batch | `src.daily_stock_tier_batch` | `src.pipeline.daily_stock_tier_batch` | Done | wrapper 유지 |
+| Financial collector | `src.financial_collector` | `src.data.collectors.financial_collector` | Done | wrapper 유지 |
+| Investor collector | `src.investor_trading_collector` | `src.data.collectors.investor_trading_collector` | Done | wrapper 유지 |
+| WFO analyzer | `src.walk_forward_analyzer` | `src.analysis.walk_forward_analyzer` | Done | wrapper 유지 |
+| CPU backtester engine | `src.backtester` | `src.backtest.cpu.backtester` | Done | wrapper + legacy import 호환 |
+| CPU strategy | `src.strategy` | `src.backtest.cpu.strategy` | Done | wrapper + legacy import 호환 |
+| CPU portfolio | `src.portfolio` | `src.backtest.cpu.portfolio` | Done | wrapper + legacy import 호환 |
+| CPU execution | `src.execution` | `src.backtest.cpu.execution` | Done | wrapper + legacy import 호환 |
+| GPU optimization library | `src.parameter_simulation_gpu_lib` | `src.optimization.gpu.*` | Done | wrapper 유지 |
+| GPU optimization entrypoint | `src.parameter_simulation_gpu` | `src.parameter_simulation_gpu_lib -> src.optimization.gpu.parameter_simulation` | Done | import-safe wrapper 유지 (#60) |
+| GPU strategy kernel | `src.backtest_strategy_gpu` | `src.backtest.gpu.*` (planned) | Pending (PR-7) | 현재는 단일 모듈 유지 |
+
+## 3. import 사용 가이드
+
+### 3.1 `src` 내부 코드(신규/수정 코드)
+
+- 구현 모듈을 직접 import 하세요.
+- 예시:
+
+```python
+# before
+from src.financial_collector import run_financial_batch
+
+# after
+from src.data.collectors.financial_collector import run_financial_batch
+```
+
+```python
+# before
+from src.backtester import BacktestEngine
+
+# after
+from src.backtest.cpu.backtester import BacktestEngine
+```
+
+## 3.2 외부 호출/기존 스크립트 호환
+
+- 기존 top-level 경로 import는 계속 동작합니다.
+- 예시:
+
+```python
+from src.pipeline_batch import run_pipeline_batch
+from src.parameter_simulation_gpu import find_optimal_parameters
+```
+
+## 4. 엔트리포인트 호환 커맨드(유지)
+
+- `python -m src.pipeline_batch`
+- `python -m src.ticker_universe_batch`
+- `python -m src.ohlcv_batch`
+- `python -m src.walk_forward_analyzer`
+- `python -m src.parameter_simulation_gpu`
+- `python -m src.main_backtest`
+- `python -m src.main_script`
+
+## 5. 남은 작업
+
+- `PR-7`: `src.backtest_strategy_gpu`를 `src.backtest.gpu/*`로 분해 후, 본 문서의 Pending 행을 Done으로 갱신합니다.

--- a/todos/2026_02_16-issue69-src-package-restructure-breakdown.md
+++ b/todos/2026_02_16-issue69-src-package-restructure-breakdown.md
@@ -294,7 +294,8 @@
   - `python -m unittest tests.test_issue60_import_side_effects tests.test_issue61_import_style_standardization tests.test_issue68_wfo_import_side_effects tests.test_issue69_entrypoint_compat -v`
 
 ### 6-12. PR-11: import 경로 변경 가이드 문서화(DoD Gate)
-- [ ] `docs/refactoring/issue69-import-path-mapping.md`: 이전 import 경로 -> 신규 경로 매핑 테이블 작성
+- [x] `docs/refactoring/issue69-import-path-mapping.md`: 이전 import 경로 -> 신규 경로 매핑 테이블 작성
+- [x] 문서에 `PR-7(backtest_strategy_gpu 분해)` 미완료 상태를 Pending으로 명시
 
 ---
 


### PR DESCRIPTION
  변경 파일:

  - docs/refactoring/issue69-import-path-mapping.md
  - todos/2026_02_16-issue69-src-package-restructure-breakdown.md

  핵심 반영:

  - Issue #69의 기존 경로 → 신규 구현 경로 매핑표 작성
  - wrapper 유지 원칙/엔트리포인트 유지 커맨드 정리
  - PR-7(backtest_strategy_gpu 분해)를 Pending으로 명시
  - todos의 PR-11 체크 완료

  참고:

  - 이번 변경은 문서/체크리스트 업데이트만이라 별도 테스트 실행은 생략했습니다.
  - PR-7은 이전에 말씀드린 대로 GPU 환경에서 진행하는 게 맞습니다.